### PR TITLE
feat(Header): Refactor Header component to use useState hook

### DIFF
--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -2,6 +2,15 @@
   padding-top: var(--size-600);
 }
 
+.primary-navigation {
+  transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
+}
+
+.primary-navigation--open {
+  opacity: 1;
+  transform: translateX(0);
+}
+
 .nav-wrapper {
   display: flex;
   justify-content: space-between;
@@ -42,6 +51,8 @@
     background: var(--clr-neutral-100);
     border-radius: var(--size-200);
     box-shadow: 0 0 0.75em rgb(0, 0, 0, 0.05);
+    /* opacity: 0;
+    transform: translateX(-100%); */
   }
 
   .primary-header[data-overlay]::before {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useState } from "react";
 import logo from "/src/assets/images/logo.svg";
 import styles from "./Header.module.css";
 import Button from "../Button/Button";
@@ -25,41 +25,15 @@ const headerNavigationLinks = [
 ];
 
 function Header() {
-  const primaryNavRef = useRef<HTMLElement>(null);
-  const navToggleRef = useRef<HTMLButtonElement>(null);
-  const primaryHeaderRef = useRef<HTMLElement>(null);
+  const [isNavOpen, setIsNavOpen] = useState(false);
 
-  useEffect(() => {
-    const handleClick = () => {
-      if (primaryNavRef.current) {
-        const isDataVisible =
-          primaryNavRef.current.hasAttribute("data-visible");
-        if (navToggleRef.current) {
-          navToggleRef.current.setAttribute(
-            "aria-expanded",
-            isDataVisible ? "false" : "true"
-          );
-        }
-        primaryNavRef.current.toggleAttribute("data-visible");
-        if (primaryHeaderRef.current) {
-          primaryHeaderRef.current.toggleAttribute("data-overlay");
-        }
-      }
-    };
-
-    if (navToggleRef.current) {
-      navToggleRef.current.addEventListener("click", handleClick);
-    }
-
-    return () => {
-      if (navToggleRef.current) {
-        navToggleRef.current.removeEventListener("click", handleClick);
-      }
-    };
-  }, []);
+  const handleToggleNav = () => {
+    setIsNavOpen(!isNavOpen);
+    console.log("isNavOpen state:", isNavOpen);
+  };
 
   return (
-    <header ref={primaryHeaderRef} className={styles["primary-header"]}>
+    <header className={styles["primary-header"]} data-overlay={isNavOpen}>
       <div className={`container`}>
         <div className={styles["nav-wrapper"]}>
           <a href="#">
@@ -68,10 +42,10 @@ function Header() {
             </svg>
           </a>
           <button
-            ref={navToggleRef}
             className={styles["mobile-nav-toggle"]}
             aria-controls="primary-navigation"
-            aria-expanded="false"
+            aria-expanded={isNavOpen}
+            onClick={handleToggleNav}
           >
             <img
               className={styles["icon-hamburger"]}
@@ -88,9 +62,11 @@ function Header() {
             <span className="visually-hidden">Menu</span>
           </button>
           <nav
-            ref={primaryNavRef}
-            className={styles["primary-navigation"]}
+            className={`${styles["primary-navigation"]} ${
+              isNavOpen ? styles["primary-navigation--open"] : ""
+            }`}
             id="primary-navigation"
+            data-visible={isNavOpen}
           >
             <ul
               aria-label="Primary"


### PR DESCRIPTION
Replace the useRef with useState in the Header component for managing the
navigation state. Update the logic for toggling the navigation menu and
applying CSS classes accordingly. Remove unnecessary event listeners and
simplify the code for better readability.